### PR TITLE
Add length as a property instead a method

### DIFF
--- a/main.js
+++ b/main.js
@@ -118,9 +118,13 @@ MegaHash.prototype.nextKey = function(key) {
 	}
 };
 
-MegaHash.prototype.length = function() {
-	// shortcut for numKeys
-	return this.stats().numKeys;
-}
+Object.defineProperty(MegaHash.prototype, 'length', {
+	get() {
+		// shortcut for numKeys
+		return this.stats().numKeys;
+	},
+  	enumerable: true,
+  	configurable: true
+});
 
 module.exports = MegaHash;


### PR DESCRIPTION
This small PR add length as a property instead a method, like the ES6 Map.
Thank you for your useful module!
All the best